### PR TITLE
Modify the USB product description

### DIFF
--- a/USB_DEVICE/App/usbd_desc.c
+++ b/USB_DEVICE/App/usbd_desc.c
@@ -67,7 +67,7 @@
 #define USBD_LANGID_STRING     1033
 #define USBD_MANUFACTURER_STRING     "STMicroelectronics"
 #define USBD_PID_FS     22336
-#define USBD_PRODUCT_STRING_FS     "STM32 Virtual ComPort"
+#define USBD_PRODUCT_STRING_FS     "SEMTECH CoreCell Virtual ComPort"
 #define USBD_CONFIGURATION_STRING_FS     "CDC Config"
 #define USBD_INTERFACE_STRING_FS     "CDC Interface"
 


### PR DESCRIPTION
The goal is to allow easy detection of the LoRa module. For the PicoGW platform (See https://github.com/Lora-net/picoGW_mcu/blob/master/src/usb_cdc/Src/usbd_desc.cpp) the description is set to "SEMTECH PicoGW Virtual ComPort".
The default string description can be confusing if the gateway is also using other STM32 :-(